### PR TITLE
fix: ensure search/rewrite actions loop back to Critic for re-scoring (#5)

### DIFF
--- a/src/trendx/agents/synthesis.py
+++ b/src/trendx/agents/synthesis.py
@@ -287,7 +287,7 @@ async def _refine_single_trend(
                     rewrite = decision.get("rewrite_content")
                     if isinstance(rewrite, dict):
                         current = _normalize_rewrite(rewrite, current)
-                    return current
+                    continue  # loop back to Critic for re-scoring
 
                 # Perform Local Vector Search
                 evidence = search_cluster_evidence(
@@ -315,14 +315,14 @@ async def _refine_single_trend(
                 final_content = extract_json(final_raw)
                 if isinstance(final_content, dict):
                     current = _normalize_rewrite(final_content, current)
-                return current
+                continue  # loop back to Critic for re-scoring
 
             # Action B: REWRITE (Direct)
             if action == "rewrite":
                 rewrite = decision.get("rewrite_content")
                 if isinstance(rewrite, dict):
                     current = _normalize_rewrite(rewrite, current)
-                return current
+                continue  # loop back to Critic for re-scoring
                 
         except Exception as exc:
             logger.warning("synthesis refine failed: %s", exc)


### PR DESCRIPTION
## Summary

The search and rewrite actions in the Synthesis Agent's refinement loop returned immediately after rewriting, bypassing the Critic quality gate. This meant rewritten drafts were never re-scored.

## Changes

### `src/trendx/agents/synthesis.py`
- Replaced `return current` → `continue` in 3 locations:
  1. After empty-query fallback rewrite (line 290)
  2. After search-then-rewrite (line 318)
  3. After direct rewrite (line 325)

Now after every action (search or rewrite), the loop continues back to Phase 1 (Critique) where the draft is re-scored. The only exits are:
- Score ≥ threshold (quality met)
- Max retries exhausted (loop ends naturally)
- Exception (error fallback)

Closes #5