### PR TITLE
feat: unify dual critic — merge auto_audit rules into Synthesis Critic prompt (#8)

### DIFF
--- a/src/trendx/agents/controller.py
+++ b/src/trendx/agents/controller.py
@@ -43,6 +43,12 @@ RETURN JSON (Strict):
 
 
 def auto_audit(text: str) -> str:
+    """Lightweight heuristic backup for tone/specificity checks.
+
+    Primary enforcement of these rules now lives in the Synthesis Critic
+    prompt (CRITIC_PROMPT rules 4 & 5 in prompts.py). This function serves
+    as a safety-net in case the LLM Critic misses an obvious violation.
+    """
     errors = []
     lower = text.lower()
     if any(x in lower for x in ["our analysis", "we propose", "in this paper", "my opinion"]):

--- a/src/trendx/agents/prompts.py
+++ b/src/trendx/agents/prompts.py
@@ -11,6 +11,8 @@ Analyze for:
 1. Vagueness (e.g., "improves performance" vs "reduces latency by 50ms").
 2. Actionability (Does "So What" tell the engineer exactly what to do?).
 3. Logic (Does the evidence support the claim?).
+4. Tone: REJECT if text uses first-person language (we/our/I/my, e.g., "our analysis", "we propose", "in this paper"). Must be neutral third-person.
+5. Specificity: REJECT if claiming improvement (e.g., "significant improvement") without concrete numbers, percentages, or benchmarks.
 
 Return JSON strictly (no markdown, no code fences):
 {{


### PR DESCRIPTION
## Summary

Eliminates the dual-critic conflict by merging the heuristic `auto_audit` rules into the LLM-based `CRITIC_PROMPT`. Previously, the Synthesis Critic and Controller's `auto_audit` enforced different rules independently, causing a ping-pong cycle.

## Changes

### `src/trendx/agents/prompts.py`
- Added rule 4 (Tone): Reject first-person language (we/our/I/my)
- Added rule 5 (Specificity): Reject vague improvement claims without numbers

### `src/trendx/agents/controller.py`
- Added docstring to `auto_audit` clarifying it's now a lightweight backup
- Primary enforcement lives in the Synthesis Critic prompt

Closes #8