### PR TITLE
feat: add memory between refinement attempts to prevent oscillation (#9)

### DIFF
--- a/configs/api-model.yaml
+++ b/configs/api-model.yaml
@@ -1,0 +1,55 @@
+llm:
+  provider: "openai"
+  model: "gpt-5-nano"
+  api_key_env: "OPENAI_API_KEY"
+  debug: true
+  debug_path: "reports/api_debug.jsonl"
+
+embeddings:
+  model: "all-MiniLM-L6-v2"
+
+storage:
+  url: "sqlite+aiosqlite:///./trendx.db"
+
+run:
+  cadence: "weekly"
+  max_items_per_source: 5
+
+agentic_synthesis:
+  enabled: true
+  retrieval_enabled: true
+  max_retries: 2
+  quality_threshold: 8
+
+sources:
+  papers:
+    enabled: true
+    arxiv:
+      query: "agentic OR tool calling OR memory"
+    semantic_scholar:
+      query: "agentic ai"
+  blogs:
+    enabled: true
+    rss_feeds:
+      - "https://example.com/rss"
+  github:
+    enabled: true
+    trending: true
+    releases: true
+    starred_updates: false
+    search_query: "agentic ai"
+  social:
+    enabled: true
+    hacker_news: true
+    reddit:
+      subreddits:
+        - "MachineLearning"
+        - "LocalLLaMA"
+        - "MLOps"
+
+trust:
+  source_weights:
+    papers: 1.0
+    github: 0.8
+    blogs: 0.6
+    social: 0.4

--- a/src/trendx/agents/synthesis.py
+++ b/src/trendx/agents/synthesis.py
@@ -206,6 +206,9 @@ async def _refine_single_trend(
     # Format the evidence context once
     evidence_blob = _format_evidence_blob(trend)
 
+    # Accumulate feedback across attempts so the Refiner doesn't undo previous fixes
+    feedback_history: list[str] = []
+
     for attempt in range(retries):
         # ---------------------------------------------------------------------
         # PHASE 1: CRITIQUE & SCORE
@@ -247,6 +250,10 @@ async def _refine_single_trend(
             return current
 
         logger.info("refining trend (score=%s/%s). Feedback: %s", score, threshold, feedback)
+
+        # Track feedback for memory across attempts
+        feedback_history.append(f"Attempt {attempt + 1} (score {score}): {feedback}")
+        history_text = "\n".join(feedback_history) if len(feedback_history) > 1 else "No previous attempts."
         
         # ---------------------------------------------------------------------
         # PHASE 2: REFINEMENT STRATEGY (DECISION)
@@ -258,6 +265,7 @@ async def _refine_single_trend(
                 summary=current["summary"],
                 so_what=current["so_what"],
                 feedback=feedback,
+                history=history_text,
             )
             decision_raw = await _call_llm(
                 stage="synthesis_refiner_decision",


### PR DESCRIPTION
## Summary

Adds feedback memory to the Synthesis Agent's refinement loop. Previously, each attempt was stateless — the Refiner only saw the current feedback and could inadvertently undo fixes from earlier attempts.

## Changes

### `src/trendx/agents/synthesis.py`
- Initialize `feedback_history: list[str]` before the refinement loop
- Append formatted feedback (attempt number + score + feedback text) each iteration
- Format history as `history_text` and pass to the Refiner prompt

### `src/trendx/agents/prompts.py`
- Added `{history}` field to `REFINER_DECISION_PROMPT`
- Added explicit instruction: "do NOT undo fixes from earlier attempts"

## Before/After

**Before:** Attempt 1 adds numbers → Attempt 2 fixes tone but removes numbers → Attempt 3: "Too vague" again (oscillation)

**After:** Attempt 2 sees "Attempt 1 (score 4): Added numbers" → keeps numbers while fixing tone → convergence

Closes #9