### PR TITLE
feat: add decision memory to Controller — include feedback_history (#10)

### DIFF
--- a/src/trendx/agents/controller.py
+++ b/src/trendx/agents/controller.py
@@ -29,6 +29,7 @@ RULES:
    - REJECT if: uses "I/We/Our", vague claims ("significant improvement" without numbers), or sounds like a paper author.
    - APPROVE if: neutral tone, specific tool names, actionable "So What".
    - You can reject MULTIPLE trends in one turn.
+   - CHECK feedback_history: If you previously rejected a draft, verify the specific issue was actually fixed before approving. Do NOT approve a draft that still has the same problem.
 5. If all approved, publish.
 
 RETURN JSON (Strict):
@@ -93,6 +94,7 @@ async def get_next_action(state, config: AppConfig) -> Dict[str, Any]:
             "summary": d.summary,
             "so_what": d.so_what,
             "status": d.status,
+            "feedback_history": d.feedback_history,
         }
         for d in state.drafts
     ]


### PR DESCRIPTION
## Summary

Gives the Controller LLM memory of its own past decisions by including `feedback_history` in the drafts payload. Previously, each call to `get_next_action` was stateless.

## Changes

### `src/trendx/agents/controller.py`
- Added `feedback_history` to `drafts_payload`
- Updated `CONTROLLER_SYSTEM_PROMPT` rule 4: "CHECK feedback_history — verify the specific issue was fixed before approving"

Closes #10