### PR TITLE
feat: implement smart merge deduplication (#6)

### DIFF
--- a/src/trendx/dedupe/basic.py
+++ b/src/trendx/dedupe/basic.py
@@ -29,6 +29,33 @@ def _ensure_embeddings(items: List[Dict[str, Any]], model_name: str) -> None:
         item["embedding"] = vec
 
 
+def _merge_items(target: Dict[str, Any], source: Dict[str, Any]) -> None:
+    """Merge metadata from source item into target item."""
+    # 1. Merge duplicate counts
+    target_count = target.get("duplicate_count", 1)
+    source_count = source.get("duplicate_count", 1)
+    target["duplicate_count"] = target_count + source_count
+
+    # 2. Merge URLs
+    if "related_urls" not in target:
+        target["related_urls"] = []
+    # Add source's main URL
+    if source.get("url") and source["url"] not in target["related_urls"] and source["url"] != target.get("url"):
+        target["related_urls"].append(source["url"])
+    # Add source's existing related_urls
+    if source.get("related_urls"):
+        for url in source["related_urls"]:
+            if url not in target["related_urls"] and url != target.get("url"):
+                target["related_urls"].append(url)
+
+    # 3. Merge Claims/Evidence
+    if "claims" not in target:
+        target["claims"] = []
+    if source.get("claims"):
+        # Simple append for now; could dedupe claims in future if needed
+        target["claims"].extend(source["claims"])
+
+
 def dedupe_items(
     items: List[Dict[str, Any]],
     embedding_model: str,
@@ -43,6 +70,14 @@ def dedupe_items(
     kept_vecs: List[np.ndarray] = []
 
     for item in items:
+        # Initialize defaults for new items
+        if "duplicate_count" not in item:
+            item["duplicate_count"] = 1
+        if "related_urls" not in item:
+            item["related_urls"] = []
+        if "claims" not in item:
+            item["claims"] = []
+
         canon = item.get("canonical_url") or item.get("url")
         text = _item_text(item)
         item_hash = simhash(text)
@@ -73,12 +108,20 @@ def dedupe_items(
             kept_vecs.append(np.array(item.get("embedding") or [], dtype=float))
             continue
 
+        # Found a duplicate! Smart merge.
         existing = kept[duplicate_idx]
         existing_score = existing.get("trust_score") or 0.0
         new_score = item.get("trust_score") or 0.0
+
         if new_score > existing_score:
+            # START MERGE: New item is better
+            _merge_items(item, existing)
             item["simhash"] = item_hash
             kept[duplicate_idx] = item
             kept_vecs[duplicate_idx] = np.array(item.get("embedding") or [], dtype=float)
+        else:
+            # START MERGE: Existing item is better
+            _merge_items(existing, item)
+            # existing is updated in-place per reference logic
 
     return kept


### PR DESCRIPTION
## Summary

Implemented 'Smart Merge' deduplication in `src/trendx/dedupe/basic.py`. Previously, when duplicates were found, the system simply kept the item with the higher trust score and discarded the other, leading to loss of valuable metadata (claims, URLs, evidence).

## Changes

### `src/trendx/dedupe/basic.py`
- Added `_merge_items(target, source)` helper function.
- Updated `dedupe_items` logic:
    - When a duplicate is found, instead of overwriting, we now call `_merge_items`.
    - **Duplicate Count**: Summed up (e.g., if Item A seen 2 times and Item B seen 3 times -> Total 5).
    - **Related URLs**: Merged into a unique list.
    - **Claims/Evidence**: Appended to the survivor's claims list.
    - **Trust Score**: The highest trust score is always preserved.

## Verification
- Verified manually with a script mocking two items with overlapping but distinct metadata.
- Confirmed that the resulting merged item contained all claims and URLs from both source items.

Closes #6