### PR TITLE
feat: add external search with Tavily (#7)

### DIFF
--- a/src/trendx/agents/synthesis.py
+++ b/src/trendx/agents/synthesis.py
@@ -15,7 +15,7 @@ from trendx.config import AgenticSynthesisConfig
 from trendx.utils.logging import get_logger
 from trendx.utils.json_extract import extract_json
 from trendx.utils.llm_debug import log_llm_event
-from trendx.tools.retrieval import search_cluster_evidence
+from trendx.tools.retrieval import search_cluster_evidence, tavily_search
 
 logger = get_logger(__name__)
 
@@ -290,15 +290,25 @@ async def _refine_single_trend(
                     return current
 
                 # Perform Local Vector Search
-                evidence = search_cluster_evidence(
+                local_evidence = search_cluster_evidence(
                     trend.get("items") or [],
                     query,
                     model_name=embedding_model,
                 )
+
+                # Perform External Web Search (New!)
+                tavily_key = agentic_cfg.get("tavily_api_key") or config.llm.tavily_api_key
+                web_evidence = await tavily_search(query, api_key=tavily_key)
+
+                # Combine Evidence
+                combined_evidence = (
+                    f"LOCAL EVIDENCE (Cluster Items):\n{local_evidence}\n\n"
+                    f"EXTERNAL WEB EVIDENCE (Fresh Search):\n{web_evidence}"
+                )
                 
                 # Rewrite using new evidence
                 final_prompt = REFINER_WITH_EVIDENCE_PROMPT.format(
-                    evidence=evidence,
+                    evidence=combined_evidence,
                     feedback=feedback,
                     title=current["title"],
                 )

--- a/src/trendx/config.py
+++ b/src/trendx/config.py
@@ -14,6 +14,7 @@ class LLMConfig(BaseModel):
     base_url: Optional[str] = None
     debug: bool = False
     debug_path: Optional[str] = None
+    tavily_api_key: Optional[str] = None
 
 
 class EmbeddingConfig(BaseModel):

--- a/src/trendx/tools/retrieval.py
+++ b/src/trendx/tools/retrieval.py
@@ -52,3 +52,51 @@ def search_cluster_evidence(
         total_len += len(entry)
 
     return "\n".join(output_lines) if output_lines else "No highly relevant evidence found."
+
+
+async def tavily_search(
+    query: str,
+    api_key: str | None = None,
+    max_results: int = 3,
+) -> str:
+    """Perform an external web search using Tavily."""
+    if not api_key:
+        return "External search unavailable: No TAVILY_API_KEY provided."
+
+    try:
+        # Try using the official client first
+        try:
+            from tavily import TavilyClient
+            client = TavilyClient(api_key=api_key)
+            resp = client.search(query, max_results=max_results)
+            results = resp.get("results", [])
+        except ImportError:
+            # Fallback to direct HTTP request if library is missing
+            import aiohttp
+            async with aiohttp.ClientSession() as session:
+                payload = {
+                    "api_key": api_key,
+                    "query": query,
+                    "max_results": max_results,
+                    "search_depth": "basic",
+                }
+                async with session.post("https://api.tavily.com/search", json=payload) as r:
+                    if r.status != 200:
+                        return f"Search failed with status {r.status}."
+                    data = await r.json()
+                    results = data.get("results", [])
+
+        if not results:
+            return "No external results found."
+
+        output = []
+        for res in results:
+            title = res.get("title", "Untitled")
+            url = res.get("url", "#")
+            content = res.get("content", "")[:300].replace("\n", " ").strip()
+            output.append(f"- [WEB] {title} ({url}): \"{content}...\"")
+
+        return "\n".join(output)
+
+    except Exception as e:
+        return f"External search error: {str(e)}"


### PR DESCRIPTION
## Summary

Implemented deep synthesis by adding external web search capabilities via Tavily. This addresses Issue #7 where the synthesis agent was limited to only local cluster data, often resulting in shallow reports when the cluster lacked specific details (e.g., adoption stats, real-world examples).

## Changes

### 1. External Search Tool (`src/trendx/tools/retrieval.py`)
- Added `tavily_search(query, api_key)`.
- Uses `tavily-python` SDK if available, falls back to direct HTTP requests.
- Returns formatted string of search results (Title, URL, Snippet).

### 2. Configuration (`src/trendx/config.py`)
- Added `tavily_api_key` to `LLMConfig`.

### 3. Synthesis Agent (`src/trendx/agents/synthesis.py`)
- Updated the `search` action handler.
- Now calls **both** `search_cluster_evidence` (Local) and `tavily_search` (External).
- Combines results into a single evidence block for the Refiner:
  ```text
  LOCAL EVIDENCE (Cluster Items):
  ...
  EXTERNAL WEB EVIDENCE (Fresh Search):
  ...
  ```

## Verification
- Verified with a mock test script ensuring that `tavily_search` is correctly imported and called by the synthesis loop when retrieval is enabled.

Closes #7