### PR TITLE
Fix GPT-5 unsupported param errors via global LiteLLM runtime config

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -2,6 +2,7 @@ llm:
   provider: "openai"
   model: "gpt-4o-mini"
   api_key_env: "OPENAI_API_KEY"
+  drop_unsupported_params: true
 
 embeddings:
   model: "all-MiniLM-L6-v2"

--- a/configs/ollama-test.yaml
+++ b/configs/ollama-test.yaml
@@ -3,6 +3,7 @@ llm:
   model: "phi4"
   base_url: "http://localhost:11434"
   api_key_env: null
+  drop_unsupported_params: true
   debug: true
   debug_path: "reports/2026-06/ollama_debug.jsonl"
 

--- a/configs/ollama.yaml
+++ b/configs/ollama.yaml
@@ -3,6 +3,7 @@ llm:
   model: "llama3.1"
   base_url: "http://localhost:11434"
   api_key_env: null
+  drop_unsupported_params: true
 
 embeddings:
   model: "all-MiniLM-L6-v2"

--- a/src/trendx/config.py
+++ b/src/trendx/config.py
@@ -12,6 +12,7 @@ class LLMConfig(BaseModel):
     model: str = "gpt-4o-mini"
     api_key_env: Optional[str] = None
     base_url: Optional[str] = None
+    drop_unsupported_params: bool = True
     debug: bool = False
     debug_path: Optional[str] = None
 
@@ -94,4 +95,9 @@ def load_config(path: str | Path) -> AppConfig:
     if not path.exists():
         raise FileNotFoundError(f"Config not found: {path}")
     data = yaml.safe_load(path.read_text()) or {}
+    llm = data.get("llm")
+    if isinstance(llm, dict):
+        # Backward compatibility for configs using dotted key syntax.
+        if "litellm.drop_params" in llm and "drop_unsupported_params" not in llm:
+            llm["drop_unsupported_params"] = bool(llm.get("litellm.drop_params"))
     return AppConfig.model_validate(data)

--- a/src/trendx/orchestrator.py
+++ b/src/trendx/orchestrator.py
@@ -9,6 +9,7 @@ from trendx.agents import controller
 from trendx.config import load_config
 from trendx.state import ReportState, TrendDraft
 from trendx.tools import wrappers
+from trendx.utils.litellm_runtime import configure_litellm
 from trendx.utils.paths import get_new_run_dir
 from trendx.utils.time import week_id
 
@@ -41,6 +42,7 @@ async def run_agent(config_path: str, week: str | None = None) -> None:
     as the 'Manager' that oversees the other agents.
     """
     config = load_config(config_path)
+    configure_litellm(config.llm)
     week = week or week_id()
     run_dir = get_new_run_dir(week)
     run_dir.mkdir(parents=True, exist_ok=True)

--- a/src/trendx/pipeline.py
+++ b/src/trendx/pipeline.py
@@ -34,6 +34,7 @@ from trendx.storage.persist import (
     save_validation_logs,
 )
 from trendx.utils.logging import get_logger
+from trendx.utils.litellm_runtime import configure_litellm
 from trendx.utils.llm_debug import enable_debug, log_run_metadata
 from trendx.utils.time import week_id
 from trendx.validate.validator import validate_payload
@@ -164,6 +165,7 @@ def _week_ids_for_backfill(weeks: int) -> List[str]:
 
 async def run_pipeline(config_path: str, week: str | None = None) -> None:
     config = load_config(config_path)
+    configure_litellm(config.llm)
     engine = get_engine(config.storage.url)
     await init_db(engine)
 

--- a/src/trendx/utils/litellm_runtime.py
+++ b/src/trendx/utils/litellm_runtime.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import litellm
+
+from trendx.config import LLMConfig
+from trendx.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def configure_litellm(llm_cfg: LLMConfig) -> None:
+    """
+    Apply process-wide LiteLLM runtime settings from TrendX config.
+    """
+    litellm.drop_params = bool(llm_cfg.drop_unsupported_params)
+    logger.info("litellm.drop_params=%s", litellm.drop_params)

--- a/tests/test_litellm_runtime.py
+++ b/tests/test_litellm_runtime.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import litellm
+
+from trendx.config import load_config
+from trendx.utils.litellm_runtime import configure_litellm
+
+
+def test_load_config_maps_legacy_litellm_drop_params(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "\n".join(
+            [
+                "llm:",
+                "  provider: openai",
+                "  model: gpt-5-nano",
+                "  litellm.drop_params: true",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = load_config(cfg_path)
+    assert cfg.llm.drop_unsupported_params is True
+
+
+def test_configure_litellm_applies_drop_params_from_config(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "\n".join(
+            [
+                "llm:",
+                "  provider: openai",
+                "  model: gpt-5-nano",
+                "  drop_unsupported_params: false",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = load_config(cfg_path)
+    original = litellm.drop_params
+    try:
+        configure_litellm(cfg.llm)
+        assert litellm.drop_params is False
+    finally:
+        litellm.drop_params = original


### PR DESCRIPTION
## Summary
This PR fixes GPT-5 (including `gpt-5-nano`) failures caused by unsupported completion params (for example `temperature=0.2`) not being dropped consistently.

Closes #23.

## What changed
- Added `llm.drop_unsupported_params` to runtime config (`LLMConfig`, default `true`).
- Added backward-compatible mapping for legacy YAML key `llm.litellm.drop_params` in `load_config()`.
- Added centralized LiteLLM runtime setup (`configure_litellm`) to apply `litellm.drop_params` once at startup.
- Applied runtime setup in both execution paths:
  - `run_pipeline()`
  - `run_agent()`
- Updated sample configs to include `drop_unsupported_params: true`.
- Added tests:
  - legacy key mapping in config loader
  - runtime application of `litellm.drop_params`

## Validation
- `PYTHONPATH=src .venv/bin/python -m pytest -q` (2 passed)
- `python3 -m compileall src/trendx tests`

## Impact
- Prevents `UnsupportedParamsError` for GPT-5-family models across claims/taxonomy/synthesis/controller paths without requiring per-module manual toggles.
- Makes unsupported-param dropping explicit and configurable via YAML.
